### PR TITLE
perf: use tl instead of html_parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,54 +38,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
-dependencies = [
- "anstyle",
- "windows-sys",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,7 +51,7 @@ checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -110,7 +62,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -122,7 +74,7 @@ dependencies = [
  "attribute-derive-macro",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -138,7 +90,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "quote-use",
- "syn 2.0.29",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -175,34 +127,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "block-buffer"
@@ -233,12 +167,9 @@ checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
+checksum = "17f6e324229dc011159fcc089755d1e2e216a90d43a7dea6853ca740b84f35e7"
 
 [[package]]
 name = "cfg-if"
@@ -274,76 +205,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a13b88d2c62ff462f88e4a121f17a82c1af05693a2f192b5c38d14de73c19f6"
-dependencies = [
- "clap_builder",
- "clap_derive",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim",
- "terminal_size",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.29",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
-
-[[package]]
 name = "collection_literals"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "186dce98367766de751c42c4f03970fc60fc012296e706ccbb9d5df9b6c1e271"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
-
-[[package]]
-name = "comrak"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "482aa5695bca086022be453c700a40c02893f1ba7098a2c88351de55341ae894"
-dependencies = [
- "clap",
- "entities",
- "memchr",
- "once_cell",
- "regex",
- "shell-words",
- "slug",
- "syntect",
- "typed-arena",
- "unicode_categories",
- "xdg",
-]
 
 [[package]]
 name = "config"
@@ -360,7 +225,7 @@ dependencies = [
  "rust-ini",
  "serde",
  "serde_json",
- "toml",
+ "toml 0.5.11",
  "yaml-rust",
 ]
 
@@ -403,15 +268,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32fast"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,12 +278,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deranged"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
-
-[[package]]
 name = "derive-where"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,7 +285,7 @@ checksum = "875a0460143f2dbcc71fd8a63f34b7c83ac66f14bead94054e7cd619c57bbb27"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -459,12 +309,6 @@ name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "drain_filter_polyfill"
@@ -500,12 +344,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "entities"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
-
-[[package]]
 name = "enum-ordinalize"
 version = "3.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,7 +353,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -525,44 +363,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
-name = "errno"
-version = "0.3.3"
+name = "eyre"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
 dependencies = [
- "errno-dragonfly",
- "libc",
- "windows-sys",
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
+name = "femark"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+checksum = "429e98d1270c60e42dc47b241b7073ffc6d29e797257b2b0c145de3e3e24af72"
 dependencies = [
  "cc",
- "libc",
-]
-
-[[package]]
-name = "fancy-regex"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
-dependencies = [
- "bit-set",
- "regex",
-]
-
-[[package]]
-name = "flate2"
-version = "1.0.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
+ "eyre",
+ "once_cell",
+ "pulldown-cmark",
+ "pulldown-cmark-frontmatter",
+ "serde",
+ "slug",
+ "thiserror",
+ "toml 0.8.12",
+ "tracing",
+ "tree-sitter",
+ "tree-sitter-c",
+ "tree-sitter-dockerfile",
+ "tree-sitter-go",
+ "tree-sitter-highlight",
+ "tree-sitter-html",
+ "tree-sitter-javascript",
+ "tree-sitter-json",
+ "tree-sitter-nix",
+ "tree-sitter-python",
+ "tree-sitter-rstml",
+ "tree-sitter-rust",
+ "tree-sitter-toml",
+ "tree-sitter-typescript",
 ]
 
 [[package]]
@@ -645,7 +484,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -686,6 +525,15 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -781,39 +629,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
-
-[[package]]
 name = "html-escape"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
 dependencies = [
  "utf8-width",
-]
-
-[[package]]
-name = "html_parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f56db07b6612644f6f7719f8ef944f75fff9d6378fdf3d316fd32194184abd"
-dependencies = [
- "doc-comment",
- "pest",
- "pest_derive",
- "serde",
- "serde_derive",
- "serde_json",
- "thiserror",
 ]
 
 [[package]]
@@ -885,6 +706,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,17 +742,6 @@ name = "inventory"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1be380c410bf0595e94992a648ea89db4dd3f3354ba54af206fd2a68cf5ac8e"
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
-]
 
 [[package]]
 name = "ipnet"
@@ -998,10 +814,11 @@ dependencies = [
 name = "leptos-mdx"
 version = "0.1.0"
 dependencies = [
- "comrak",
+ "femark",
  "frontmatter",
- "html_parser",
  "leptos",
+ "regex",
+ "tl",
 ]
 
 [[package]]
@@ -1059,7 +876,7 @@ dependencies = [
  "quote",
  "rstml",
  "serde",
- "syn 2.0.29",
+ "syn 2.0.58",
  "walkdir",
 ]
 
@@ -1080,7 +897,7 @@ dependencies = [
  "quote",
  "rstml",
  "server_fn_macro",
- "syn 2.0.29",
+ "syn 2.0.58",
  "tracing",
  "uuid",
 ]
@@ -1127,25 +944,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
-name = "line-wrap"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9"
-dependencies = [
- "safemem",
-]
-
-[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
@@ -1257,28 +1059,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
-name = "onig"
-version = "6.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c4b31c8722ad9171c6d77d3557db078cab2bd50afcc9d09c8b315c59df8ca4f"
-dependencies = [
- "bitflags",
- "libc",
- "once_cell",
- "onig_sys",
-]
-
-[[package]]
-name = "onig_sys"
-version = "69.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
 name = "ordered-multimap"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1366,7 +1146,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1397,7 +1177,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1413,33 +1193,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkg-config"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
-
-[[package]]
-name = "plist"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdc0001cfea3db57a2e24bc0d818e9e20e554b5f97fabb9bc231dc240269ae06"
-dependencies = [
- "base64 0.21.3",
- "indexmap 1.9.3",
- "line-wrap",
- "quick-xml",
- "serde",
- "time",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c64d9ba0963cdcea2e1b2230fbae2bab30eb25a174be395c41e764bfb65dd62"
 dependencies = [
  "proc-macro2",
- "syn 2.0.29",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1479,9 +1239,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1494,25 +1254,37 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.58",
  "version_check",
  "yansi",
 ]
 
 [[package]]
-name = "quick-xml"
-version = "0.29.0"
+name = "pulldown-cmark"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b9228215d82c7b61490fec1de287136b5de6f5700f6e58ea9ad61a7964ca51"
+checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
 dependencies = [
+ "bitflags 2.5.0",
+ "getopts",
  "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-frontmatter"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d796ebc3f9fe89e2267a102d358a7f107488b5fefae07d25a990efbe1feab60"
+dependencies = [
+ "pulldown-cmark",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -1526,7 +1298,7 @@ dependencies = [
  "derive-where",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1535,14 +1307,14 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.9.4"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1552,9 +1324,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.7"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49530408a136e16e5b486e883fbb6ba058e8e4e8ae6621a77b048b314336e629"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1563,9 +1335,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.5"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "reqwest"
@@ -1608,7 +1380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
 dependencies = [
  "base64 0.13.1",
- "bitflags",
+ "bitflags 1.3.2",
  "serde",
 ]
 
@@ -1621,7 +1393,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.58",
  "syn_derive",
  "thiserror",
 ]
@@ -1649,30 +1421,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustix"
-version = "0.37.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
-dependencies = [
- "bitflags",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys",
- "windows-sys",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
-
-[[package]]
-name = "safemem"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "same-file"
@@ -1723,7 +1475,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1746,6 +1498,15 @@ dependencies = [
  "percent-encoding",
  "serde",
  "thiserror",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1779,7 +1540,7 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "server_fn_macro_default",
- "syn 2.0.29",
+ "syn 2.0.58",
  "thiserror",
  "xxhash-rust",
 ]
@@ -1794,7 +1555,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.29",
+ "syn 2.0.58",
  "xxhash-rust",
 ]
 
@@ -1804,7 +1565,7 @@ version = "0.5.0-beta"
 source = "git+https://github.com/leptos-rs/leptos.git?branch=islands#9e8b559e5193a4975b3576aa4da5cfb3ee08580e"
 dependencies = [
  "server_fn_macro",
- "syn 2.0.29",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1817,12 +1578,6 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
-
-[[package]]
-name = "shell-words"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "slab"
@@ -1879,12 +1634,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1897,9 +1646,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.29"
+version = "2.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1915,87 +1664,27 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
-]
-
-[[package]]
-name = "syntect"
-version = "5.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02b4b303bf8d08bfeb0445cba5068a3d306b6baece1d5582171a9bf49188f91"
-dependencies = [
- "bincode",
- "bitflags",
- "fancy-regex",
- "flate2",
- "fnv",
- "once_cell",
- "onig",
- "plist",
- "regex-syntax",
- "serde",
- "serde_json",
- "thiserror",
- "walkdir",
- "yaml-rust",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
-dependencies = [
- "rustix",
- "windows-sys",
+ "syn 2.0.58",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.47"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.47"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
-]
-
-[[package]]
-name = "time"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
-dependencies = [
- "deranged",
- "itoa",
- "serde",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
-
-[[package]]
-name = "time-macros"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a942f44339478ef67935ab2bbaec2fb0322496cf3cbe84b261e06ac3814c572"
-dependencies = [
- "time-core",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2012,6 +1701,12 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tl"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b130bd8a58c163224b44e217b4239ca7b927d82bf6cc2fea1fc561d15056e3f7"
 
 [[package]]
 name = "tokio"
@@ -2052,6 +1747,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
+dependencies = [
+ "indexmap 2.0.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2077,7 +1806,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2090,16 +1819,151 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e747b1f9b7b931ed39a548c1fae149101497de3c1fc8d9e18c62c1a66c683d3d"
+dependencies = [
+ "cc",
+ "regex",
+]
+
+[[package]]
+name = "tree-sitter-c"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bbd5f3d8658c08581f8f2adac6c391c2e9fa00fe9246bf6c5f52213b9cc6b72"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-dockerfile"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01e314ed278a8392df8579f3a2321959118cdaced00cf90cc9a1230c6f7637a5"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-go"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad6d11f19441b961af2fda7f12f5d0dac325f6d6de83836a1d3750018cc5114"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-highlight"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "042342584c5a7a0b833d9fc4e2bdab3f9868ddc6c4b339a1e01451c6720868bc"
+dependencies = [
+ "regex",
+ "thiserror",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-html"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "184e6b77953a354303dc87bf5fe36558c83569ce92606e7b382a0dc1b7443443"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-javascript"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d015c02ea98b62c806f7329ff71c383286dfc3a7a7da0cc484f6e42922f73c2c"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-json"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90b04c4e1a92139535eb9fca4ec8fa9666cc96b618005d3ae35f3c957fa92f92"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-nix"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8c93b7dd2afcd9667daae048135be9ee268e9e3900f4d7d0556a63ec5336b1"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-python"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c93b1b1fbd0d399db3445f51fd3058e43d0b4dcff62ddbdb46e66550978aa5"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-rstml"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27c3698a301464184e121c8e963440516c7a8295003776c166eb8b07dcca435"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0832309b0b2b6d33760ce5c0e818cb47e1d72b468516bfe4134408926fa7594"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-toml"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca517f578a98b23d20780247cc2688407fa81effad5b627a5a364ec3339b53e8"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8bc1d2c24276a48ef097a71b56888ac9db63717e8f8d0b324668a27fd619670"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
-
-[[package]]
-name = "typed-arena"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typed-builder"
@@ -2123,6 +1987,15 @@ name = "ucd-trie"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+
+[[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"
@@ -2152,16 +2025,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
-
-[[package]]
-name = "unicode_categories"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "url"
@@ -2179,12 +2052,6 @@ name = "utf8-width"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
@@ -2247,7 +2114,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.58",
  "wasm-bindgen-shared",
 ]
 
@@ -2281,7 +2148,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.58",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2400,6 +2267,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
+name = "winnow"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c976aaaa0e1f90dbb21e9587cdaf1d9679a1cde8875c0d6bd83ab96a208352"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2408,12 +2284,6 @@ dependencies = [
  "cfg-if",
  "windows-sys",
 ]
-
-[[package]]
-name = "xdg"
-version = "2.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "xxhash-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 leptos = { git = "https://github.com/leptos-rs/leptos.git", branch = "islands", features = [ "ssr", "islands" ] }
-html_parser = "0.7.0"
-comrak = "0.18.0"
 frontmatter = "0.4.0"
+femark = "0.1.5"
+tl = "0.7.8"
+regex = "1.10.4"

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -1,8 +1,6 @@
 use std::error::Error;
 
-use comrak::{
-    markdown_to_html_with_plugins, plugins::syntect::SyntectAdapter, ComrakOptions, ComrakPlugins,
-};
+use femark::{process_markdown_to_html, HTMLOutput};
 
 /// parse a markdown source into its optional frontmatter and the HTML string.
 pub fn parse(source: &str) -> Result<(Option<frontmatter::Yaml>, String), Box<dyn Error>> {
@@ -17,35 +15,8 @@ fn extract_frontmatter(input: &str) -> Result<(Option<frontmatter::Yaml>, &str),
 }
 
 fn md_to_html(s: &str) -> String {
-    let options = ComrakOptions {
-        parse: comrak::ComrakParseOptions {
-            smart: true,
-            ..comrak::ComrakParseOptions::default()
-        },
-
-        extension: comrak::ComrakExtensionOptions {
-            autolink: true,
-            table: true,
-            description_lists: true,
-            superscript: true,
-            strikethrough: true,
-            footnotes: true,
-            ..comrak::ComrakExtensionOptions::default()
-        },
-
-        render: comrak::ComrakRenderOptions {
-            unsafe_: true,
-            github_pre_lang: true,
-            hardbreaks: true,
-            full_info_string: true,
-            ..comrak::ComrakRenderOptions::default()
-        },
+    let Ok(HTMLOutput { content, .. }) = process_markdown_to_html(s) else {
+        panic!("Error parsing markdown");
     };
-    let mut plugins = ComrakPlugins::default();
-
-    let adapter = SyntectAdapter::new("InspiredGitHub");
-    plugins.render.codefence_syntax_highlighter = Some(&adapter);
-
-    let html = markdown_to_html_with_plugins(s, &options, &plugins);
-    html
+    content
 }

--- a/src/mdx.rs
+++ b/src/mdx.rs
@@ -1,31 +1,25 @@
-use std::collections::HashMap;
-
-use crate::markdown::parse;
-use html_parser::{Dom, Element};
 use leptos::{
     component, html::ElementDescriptor, warn, Children, Fragment, HtmlElement, IntoView, View,
 };
+use regex::Regex;
+use std::collections::HashMap;
+use tl::{HTMLTag, Node};
+
+use crate::markdown::parse;
 
 #[component]
 /// Renders a markdown source into a Leptos component.
 /// Custom components can be used in the markdown source.
 pub fn Mdx(source: String, components: Components) -> impl IntoView {
-    let (_fm, mut html) = parse(&source).expect("invalid mdx");
+    let (_fm, html) = parse(&source).expect("invalid mdx");
     // TODO: we could expose frontmatter in the context so components can use its value
 
-    html = html.replace(
-        "<span style=\"color:#323232;\">\n</span>",
-        "<span style=\"color:#323232;\"><br/></span>",
-    ); // TODO: this is a hack to replace empty lines with <br/>
-    html = html.replace("    ", "&nbsp;&nbsp;&nbsp;&nbsp;"); // TODO: this is a hack to replace tabs with spaces
-
-    let dom = Dom::parse(&html).expect("invalid html");
+    let dom = tl::parse(&html, tl::ParserOptions::default()).expect("invalid html");
 
     let mut root_views = vec![];
-    for node in dom.children {
-        if let Some(el) = node.element() {
-            root_views.push(process_element(el, &components));
-        }
+    for node_handle in dom.children() {
+        let node = node_handle.get(dom.parser()).expect("not a node");
+        root_views.push(process_element(node, dom.parser(), &components, true));
     }
 
     Fragment::new(root_views)
@@ -85,175 +79,239 @@ impl Components {
     }
 }
 
-pub fn process_element(el: &Element, components: &Components) -> View {
-    let mut child_views = vec![];
-    for child in &el.children {
-        match child {
-            html_parser::Node::Element(el_child) => {
-                child_views.push(process_element(el_child, components));
+pub fn process_element(
+    el: &Node,
+    parser: &tl::Parser,
+    components: &Components,
+    parse_new_lines: bool,
+) -> View {
+    match el {
+        Node::Comment(_comment) => return ().into_view(),
+        Node::Raw(raw) => {
+            let text = String::from_utf8(raw.as_bytes().to_vec());
+
+            if let Ok(t) = text {
+                if parse_new_lines {
+                    /*
+                     * Replace new lines with <br /> only if they are preceded and followed by text.
+                     * to avoid adding <br /> to empty lines.
+                     */
+                    let reg = Regex::new(r".+(\n).+").unwrap();
+
+                    let t = reg
+                        .replace_all(&t, |caps: &regex::Captures| format!("{} <br />", &caps[0]));
+
+                    return t.into_view();
+                }
+
+                return t.into_view();
+            } else {
+                warn!("error parsing raw text: {:?}", text);
+                return ().into_view();
             }
-            html_parser::Node::Text(text) => {
-                child_views.push(text.clone().into_view());
-            }
-            _ => {}
         }
-    }
+        Node::Tag(tag) => {
+            let mut child_views = vec![];
 
-    // Custom elements
-    if let Some(component) = components.get(&el.name) {
-        let cmp = component(MdxComponentProps {
-            id: el.id.clone(),
-            classes: el.classes.clone(),
-            attributes: el.attributes.clone(),
-            children: Box::new(move || Fragment::new(child_views)),
-        });
-        return cmp;
-    }
+            let nodes = tag.children();
 
-    // HTML elements
-    match el.name.as_str() {
-        "html" => html_element(el, child_views, leptos::html::html()),
-        "base" => html_element(el, child_views, leptos::html::base()),
-        "head" => html_element(el, child_views, leptos::html::head()),
-        "link" => html_element(el, child_views, leptos::html::link()),
-        "meta" => html_element(el, child_views, leptos::html::meta()),
-        "style" => html_element(el, child_views, leptos::html::style()),
-        "title" => html_element(el, child_views, leptos::html::title()),
-        "body" => html_element(el, child_views, leptos::html::body()),
-        "address" => html_element(el, child_views, leptos::html::address()),
-        "article" => html_element(el, child_views, leptos::html::article()),
-        "aside" => html_element(el, child_views, leptos::html::aside()),
-        "footer" => html_element(el, child_views, leptos::html::footer()),
-        "header" => html_element(el, child_views, leptos::html::header()),
-        "hgroup" => html_element(el, child_views, leptos::html::hgroup()),
-        "h1" => html_element(el, child_views, leptos::html::h1()),
-        "h2" => html_element(el, child_views, leptos::html::h2()),
-        "h3" => html_element(el, child_views, leptos::html::h3()),
-        "h4" => html_element(el, child_views, leptos::html::h4()),
-        "h5" => html_element(el, child_views, leptos::html::h5()),
-        "h6" => html_element(el, child_views, leptos::html::h6()),
-        "main" => html_element(el, child_views, leptos::html::main()),
-        "nav" => html_element(el, child_views, leptos::html::nav()),
-        "section" => html_element(el, child_views, leptos::html::section()),
-        "blockquote" => html_element(el, child_views, leptos::html::blockquote()),
-        "dd" => html_element(el, child_views, leptos::html::dd()),
-        "div" => html_element(el, child_views, leptos::html::div()),
-        "dl" => html_element(el, child_views, leptos::html::dl()),
-        "dt" => html_element(el, child_views, leptos::html::dt()),
-        "figcaption" => html_element(el, child_views, leptos::html::figcaption()),
-        "figure" => html_element(el, child_views, leptos::html::figure()),
-        "hr" => html_element(el, child_views, leptos::html::hr()),
-        "li" => html_element(el, child_views, leptos::html::li()),
-        "ol" => html_element(el, child_views, leptos::html::ol()),
-        "p" => html_element(el, child_views, leptos::html::p()),
-        "pre" => html_element(el, child_views, leptos::html::pre()),
-        "ul" => html_element(el, child_views, leptos::html::ul()),
-        "a" => html_element(el, child_views, leptos::html::a()),
-        "abbr" => html_element(el, child_views, leptos::html::abbr()),
-        "b" => html_element(el, child_views, leptos::html::b()),
-        "bdi" => html_element(el, child_views, leptos::html::bdi()),
-        "bdo" => html_element(el, child_views, leptos::html::bdo()),
-        "br" => html_element(el, child_views, leptos::html::br()),
-        "cite" => html_element(el, child_views, leptos::html::cite()),
-        "code" => html_element(el, child_views, leptos::html::code()),
-        "data" => html_element(el, child_views, leptos::html::data()),
-        "dfn" => html_element(el, child_views, leptos::html::dfn()),
-        "em" => html_element(el, child_views, leptos::html::em()),
-        "i" => html_element(el, child_views, leptos::html::i()),
-        "kbd" => html_element(el, child_views, leptos::html::kbd()),
-        "mark" => html_element(el, child_views, leptos::html::mark()),
-        "q" => html_element(el, child_views, leptos::html::q()),
-        "rp" => html_element(el, child_views, leptos::html::rp()),
-        "rt" => html_element(el, child_views, leptos::html::rt()),
-        "ruby" => html_element(el, child_views, leptos::html::ruby()),
-        "s" => html_element(el, child_views, leptos::html::s()),
-        "samp" => html_element(el, child_views, leptos::html::samp()),
-        "small" => html_element(el, child_views, leptos::html::small()),
-        "span" => html_element(el, child_views, leptos::html::span()),
-        "strong" => html_element(el, child_views, leptos::html::strong()),
-        "sub" => html_element(el, child_views, leptos::html::sub()),
-        "sup" => html_element(el, child_views, leptos::html::sup()),
-        "time" => html_element(el, child_views, leptos::html::time()),
-        "u" => html_element(el, child_views, leptos::html::u()),
-        "var" => html_element(el, child_views, leptos::html::var()),
-        "wbr" => html_element(el, child_views, leptos::html::wbr()),
-        "area" => html_element(el, child_views, leptos::html::area()),
-        "audio" => html_element(el, child_views, leptos::html::audio()),
-        "img" => html_element(el, child_views, leptos::html::img()),
-        "map" => html_element(el, child_views, leptos::html::map()),
-        "track" => html_element(el, child_views, leptos::html::track()),
-        "video" => html_element(el, child_views, leptos::html::video()),
-        "embed" => html_element(el, child_views, leptos::html::embed()),
-        "iframe" => html_element(el, child_views, leptos::html::iframe()),
-        "object" => html_element(el, child_views, leptos::html::object()),
-        "param" => html_element(el, child_views, leptos::html::param()),
-        "picture" => html_element(el, child_views, leptos::html::picture()),
-        "portal" => html_element(el, child_views, leptos::html::portal()),
-        "source" => html_element(el, child_views, leptos::html::source()),
-        "svg" => html_element(el, child_views, leptos::html::svg()),
-        "math" => html_element(el, child_views, leptos::html::math()),
-        "canvas" => html_element(el, child_views, leptos::html::canvas()),
-        "noscript" => html_element(el, child_views, leptos::html::noscript()),
-        "script" => html_element(el, child_views, leptos::html::script()),
-        "del" => html_element(el, child_views, leptos::html::del()),
-        "ins" => html_element(el, child_views, leptos::html::ins()),
-        "caption" => html_element(el, child_views, leptos::html::caption()),
-        "col" => html_element(el, child_views, leptos::html::col()),
-        "colgroup" => html_element(el, child_views, leptos::html::colgroup()),
-        "table" => html_element(el, child_views, leptos::html::table()),
-        "tbody" => html_element(el, child_views, leptos::html::tbody()),
-        "td" => html_element(el, child_views, leptos::html::td()),
-        "tfoot" => html_element(el, child_views, leptos::html::tfoot()),
-        "th" => html_element(el, child_views, leptos::html::th()),
-        "thead" => html_element(el, child_views, leptos::html::thead()),
-        "tr" => html_element(el, child_views, leptos::html::tr()),
-        "button" => html_element(el, child_views, leptos::html::button()),
-        "datalist" => html_element(el, child_views, leptos::html::datalist()),
-        "fieldset" => html_element(el, child_views, leptos::html::fieldset()),
-        "form" => html_element(el, child_views, leptos::html::form()),
-        "input" => html_element(el, child_views, leptos::html::input()),
-        "label" => html_element(el, child_views, leptos::html::label()),
-        "legend" => html_element(el, child_views, leptos::html::legend()),
-        "meter" => html_element(el, child_views, leptos::html::meter()),
-        "optgroup" => html_element(el, child_views, leptos::html::optgroup()),
-        "option" => html_element(el, child_views, leptos::html::option()),
-        "output" => html_element(el, child_views, leptos::html::output()),
-        "progress" => html_element(el, child_views, leptos::html::progress()),
-        "select" => html_element(el, child_views, leptos::html::select()),
-        "textarea" => html_element(el, child_views, leptos::html::textarea()),
-        "details" => html_element(el, child_views, leptos::html::details()),
-        "dialog" => html_element(el, child_views, leptos::html::dialog()),
-        "menu" => html_element(el, child_views, leptos::html::menu()),
-        "summary" => html_element(el, child_views, leptos::html::summary()),
-        "slot" => html_element(el, child_views, leptos::html::slot()),
-        "template" => html_element(el, child_views, leptos::html::template()),
-        _ => {
-            warn!("unknown element {}", el.name);
-            ().into_view()
+            // Process children
+            nodes.top().iter().for_each(|node_handle| {
+                let node = node_handle.get(parser).expect("not a node");
+
+                /*
+                 * Inside code blocks we want to keep the new lines as they are.
+                 */
+                if tag.name().as_utf8_str() == "code" || tag.name().as_utf8_str() == "pre" {
+                    child_views.push(process_element(node, parser, components, false));
+                } else {
+                    child_views.push(process_element(node, parser, components, parse_new_lines));
+                }
+            });
+
+            let name_ref = tag.name().as_utf8_str();
+            let name = name_ref.as_ref();
+
+            // Custom elements
+            if let Some(component) = components.get(name) {
+                let attributes = tag.attributes();
+
+                let classes = attributes.class_iter().map_or(Vec::new(), |class_list| {
+                    class_list.map(|c| c.to_string()).collect()
+                });
+
+                let attributes_map = attributes
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), v.map(|v| v.to_string())))
+                    .collect();
+
+                return component(MdxComponentProps {
+                    id: attributes.id().map(|id| id.as_utf8_str().to_string()),
+                    classes,
+                    attributes: attributes_map,
+                    children: Box::new(move || Fragment::new(child_views)),
+                });
+            }
+
+            // HTML elements
+            match name {
+                "html" => html_element(&tag.clone(), child_views, leptos::html::html()),
+                "base" => html_element(&tag.clone(), child_views, leptos::html::base()),
+                "head" => html_element(&tag.clone(), child_views, leptos::html::head()),
+                "link" => html_element(&tag.clone(), child_views, leptos::html::link()),
+                "meta" => html_element(&tag.clone(), child_views, leptos::html::meta()),
+                "style" => html_element(&tag.clone(), child_views, leptos::html::style()),
+                "title" => html_element(&tag.clone(), child_views, leptos::html::title()),
+                "body" => html_element(&tag.clone(), child_views, leptos::html::body()),
+                "address" => html_element(&tag.clone(), child_views, leptos::html::address()),
+                "article" => html_element(&tag.clone(), child_views, leptos::html::article()),
+                "aside" => html_element(&tag.clone(), child_views, leptos::html::aside()),
+                "footer" => html_element(&tag.clone(), child_views, leptos::html::footer()),
+                "header" => html_element(&tag.clone(), child_views, leptos::html::header()),
+                "hgroup" => html_element(&tag.clone(), child_views, leptos::html::hgroup()),
+                "h1" => html_element(&tag.clone(), child_views, leptos::html::h1()),
+                "h2" => html_element(&tag.clone(), child_views, leptos::html::h2()),
+                "h3" => html_element(&tag.clone(), child_views, leptos::html::h3()),
+                "h4" => html_element(&tag.clone(), child_views, leptos::html::h4()),
+                "h5" => html_element(&tag.clone(), child_views, leptos::html::h5()),
+                "h6" => html_element(&tag.clone(), child_views, leptos::html::h6()),
+                "main" => html_element(&tag.clone(), child_views, leptos::html::main()),
+                "nav" => html_element(&tag.clone(), child_views, leptos::html::nav()),
+                "section" => html_element(&tag.clone(), child_views, leptos::html::section()),
+                "blockquote" => html_element(&tag.clone(), child_views, leptos::html::blockquote()),
+                "dd" => html_element(&tag.clone(), child_views, leptos::html::dd()),
+                "div" => html_element(&tag.clone(), child_views, leptos::html::div()),
+                "dl" => html_element(&tag.clone(), child_views, leptos::html::dl()),
+                "dt" => html_element(&tag.clone(), child_views, leptos::html::dt()),
+                "figcaption" => html_element(&tag.clone(), child_views, leptos::html::figcaption()),
+                "figure" => html_element(&tag.clone(), child_views, leptos::html::figure()),
+                "hr" => html_element(&tag.clone(), child_views, leptos::html::hr()),
+                "li" => html_element(&tag.clone(), child_views, leptos::html::li()),
+                "ol" => html_element(&tag.clone(), child_views, leptos::html::ol()),
+                "p" => html_element(&tag.clone(), child_views, leptos::html::p()),
+                "pre" => html_element(&tag.clone(), child_views, leptos::html::pre()),
+                "ul" => html_element(&tag.clone(), child_views, leptos::html::ul()),
+                "a" => html_element(&tag.clone(), child_views, leptos::html::a()),
+                "abbr" => html_element(&tag.clone(), child_views, leptos::html::abbr()),
+                "b" => html_element(&tag.clone(), child_views, leptos::html::b()),
+                "bdi" => html_element(&tag.clone(), child_views, leptos::html::bdi()),
+                "bdo" => html_element(&tag.clone(), child_views, leptos::html::bdo()),
+                "br" => html_element(&tag.clone(), child_views, leptos::html::br()),
+                "cite" => html_element(&tag.clone(), child_views, leptos::html::cite()),
+                "code" => html_element(&tag.clone(), child_views, leptos::html::code()),
+                "data" => html_element(&tag.clone(), child_views, leptos::html::data()),
+                "dfn" => html_element(&tag.clone(), child_views, leptos::html::dfn()),
+                "em" => html_element(&tag.clone(), child_views, leptos::html::em()),
+                "i" => html_element(&tag.clone(), child_views, leptos::html::i()),
+                "kbd" => html_element(&tag.clone(), child_views, leptos::html::kbd()),
+                "mark" => html_element(&tag.clone(), child_views, leptos::html::mark()),
+                "q" => html_element(&tag.clone(), child_views, leptos::html::q()),
+                "rp" => html_element(&tag.clone(), child_views, leptos::html::rp()),
+                "rt" => html_element(&tag.clone(), child_views, leptos::html::rt()),
+                "ruby" => html_element(&tag.clone(), child_views, leptos::html::ruby()),
+                "s" => html_element(&tag.clone(), child_views, leptos::html::s()),
+                "samp" => html_element(&tag.clone(), child_views, leptos::html::samp()),
+                "small" => html_element(&tag.clone(), child_views, leptos::html::small()),
+                "span" => html_element(&tag.clone(), child_views, leptos::html::span()),
+                "strong" => html_element(&tag.clone(), child_views, leptos::html::strong()),
+                "sub" => html_element(&tag.clone(), child_views, leptos::html::sub()),
+                "sup" => html_element(&tag.clone(), child_views, leptos::html::sup()),
+                "time" => html_element(&tag.clone(), child_views, leptos::html::time()),
+                "u" => html_element(&tag.clone(), child_views, leptos::html::u()),
+                "var" => html_element(&tag.clone(), child_views, leptos::html::var()),
+                "wbr" => html_element(&tag.clone(), child_views, leptos::html::wbr()),
+                "area" => html_element(&tag.clone(), child_views, leptos::html::area()),
+                "audio" => html_element(&tag.clone(), child_views, leptos::html::audio()),
+                "img" => html_element(&tag.clone(), child_views, leptos::html::img()),
+                "map" => html_element(&tag.clone(), child_views, leptos::html::map()),
+                "track" => html_element(&tag.clone(), child_views, leptos::html::track()),
+                "video" => html_element(&tag.clone(), child_views, leptos::html::video()),
+                "embed" => html_element(&tag.clone(), child_views, leptos::html::embed()),
+                "iframe" => html_element(&tag.clone(), child_views, leptos::html::iframe()),
+                "object" => html_element(&tag.clone(), child_views, leptos::html::object()),
+                "param" => html_element(&tag.clone(), child_views, leptos::html::param()),
+                "picture" => html_element(&tag.clone(), child_views, leptos::html::picture()),
+                "portal" => html_element(&tag.clone(), child_views, leptos::html::portal()),
+                "source" => html_element(&tag.clone(), child_views, leptos::html::source()),
+                "svg" => html_element(&tag.clone(), child_views, leptos::html::svg()),
+                "math" => html_element(&tag.clone(), child_views, leptos::html::math()),
+                "canvas" => html_element(&tag.clone(), child_views, leptos::html::canvas()),
+                "noscript" => html_element(&tag.clone(), child_views, leptos::html::noscript()),
+                "script" => html_element(&tag.clone(), child_views, leptos::html::script()),
+                "del" => html_element(&tag.clone(), child_views, leptos::html::del()),
+                "ins" => html_element(&tag.clone(), child_views, leptos::html::ins()),
+                "caption" => html_element(&tag.clone(), child_views, leptos::html::caption()),
+                "col" => html_element(&tag.clone(), child_views, leptos::html::col()),
+                "colgroup" => html_element(&tag.clone(), child_views, leptos::html::colgroup()),
+                "table" => html_element(&tag.clone(), child_views, leptos::html::table()),
+                "tbody" => html_element(&tag.clone(), child_views, leptos::html::tbody()),
+                "td" => html_element(&tag.clone(), child_views, leptos::html::td()),
+                "tfoot" => html_element(&tag.clone(), child_views, leptos::html::tfoot()),
+                "th" => html_element(&tag.clone(), child_views, leptos::html::th()),
+                "thead" => html_element(&tag.clone(), child_views, leptos::html::thead()),
+                "tr" => html_element(&tag.clone(), child_views, leptos::html::tr()),
+                "button" => html_element(&tag.clone(), child_views, leptos::html::button()),
+                "datalist" => html_element(&tag.clone(), child_views, leptos::html::datalist()),
+                "fieldset" => html_element(&tag.clone(), child_views, leptos::html::fieldset()),
+                "form" => html_element(&tag.clone(), child_views, leptos::html::form()),
+                "input" => html_element(&tag.clone(), child_views, leptos::html::input()),
+                "label" => html_element(&tag.clone(), child_views, leptos::html::label()),
+                "legend" => html_element(&tag.clone(), child_views, leptos::html::legend()),
+                "meter" => html_element(&tag.clone(), child_views, leptos::html::meter()),
+                "optgroup" => html_element(&tag.clone(), child_views, leptos::html::optgroup()),
+                "option" => html_element(&tag.clone(), child_views, leptos::html::option()),
+                "output" => html_element(&tag.clone(), child_views, leptos::html::output()),
+                "progress" => html_element(&tag.clone(), child_views, leptos::html::progress()),
+                "select" => html_element(&tag.clone(), child_views, leptos::html::select()),
+                "textarea" => html_element(&tag.clone(), child_views, leptos::html::textarea()),
+                "details" => html_element(&tag.clone(), child_views, leptos::html::details()),
+                "dialog" => html_element(&tag.clone(), child_views, leptos::html::dialog()),
+                "menu" => html_element(&tag.clone(), child_views, leptos::html::menu()),
+                "summary" => html_element(&tag.clone(), child_views, leptos::html::summary()),
+                "slot" => html_element(&tag.clone(), child_views, leptos::html::slot()),
+                "template" => html_element(&tag.clone(), child_views, leptos::html::template()),
+                _ => {
+                    warn!("unknown element {}", name);
+                    ().into_view()
+                }
+            }
         }
     }
 }
 
 fn html_element<Element>(
-    element: &html_parser::Element,
+    element: &HTMLTag,
     children: Vec<View>,
     mut leptos_el: HtmlElement<Element>,
 ) -> View
 where
     Element: ElementDescriptor + 'static,
 {
-    if let Some(v) = &element.id {
+    let attributes = element.attributes();
+
+    let id = attributes.id().map(|id| id.as_utf8_str().to_string());
+
+    let attributes_map: HashMap<String, Option<String>> = attributes
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.map(|v| v.to_string())))
+        .collect();
+
+    let classes = attributes.class_iter().map_or(Vec::new(), |class_list| {
+        class_list.map(|c| c.to_string()).collect()
+    });
+
+    if let Some(v) = id {
         leptos_el = leptos_el.id(v.clone());
     }
 
-    for (k, v) in &element.attributes {
+    for (k, v) in attributes_map {
         if let Some(v) = v {
             leptos_el = leptos_el.attr(k.clone(), v);
         }
     }
 
-    if !element.classes.is_empty() {
-        leptos_el = leptos_el.attr("class", element.classes.join(" "));
+    if !classes.is_empty() {
+        leptos_el = leptos_el.attr("class", classes.join(" "));
     }
 
     for child in children {


### PR DESCRIPTION
- Changes [html_parser](https://docs.rs/html_parser/latest/html_parser/) to [tl](https://docs.rs/crate/tl/latest)
- Changes [comrak](https://docs.rs/crate/comrak/latest) to [femark](https://crates.io/crates/femark)

Test with all the existing pages before merging

Benchmarks:
| Command | Mean [s] | Min [s] | Max [s] |
|:---|---:|---:|---:|
| `new-parser` | 1.439 ± 0.062 | 1.387 | 1.560 |
|  `old-parser`  | 4.562 ± 0.073 | 4.473 | 4.691 |